### PR TITLE
chore: use named import from node-stream-zip

### DIFF
--- a/src/utils/getLambdaFunctionContents.spec.ts
+++ b/src/utils/getLambdaFunctionContents.spec.ts
@@ -10,12 +10,10 @@ const { mockZip } = vi.hoisted(() => ({
 }));
 
 vi.mock("node-stream-zip", () => ({
-  default: {
-    async: class {
-      entries = mockZip.entries;
-      entryData = mockZip.entryData;
-      close = mockZip.close;
-    },
+  StreamZipAsync: class {
+    entries = mockZip.entries;
+    entryData = mockZip.entryData;
+    close = mockZip.close;
   },
 }));
 

--- a/src/utils/getLambdaFunctionContents.ts
+++ b/src/utils/getLambdaFunctionContents.ts
@@ -1,4 +1,4 @@
-import StreamZip from "node-stream-zip";
+import { type ZipEntry, StreamZipAsync } from "node-stream-zip";
 const PACKAGE_JSON_FILENAME = "package.json";
 
 export type LambdaFunctionContents = {
@@ -24,11 +24,11 @@ export type LambdaFunctionContents = {
 export const getLambdaFunctionContents = async (
   zipPath: string,
 ): Promise<LambdaFunctionContents> => {
-  const zip = new StreamZip.async({ file: zipPath });
+  const zip = new StreamZipAsync({ file: zipPath });
 
   const packageJsonContents = [];
 
-  let zipEntries: Record<string, StreamZip.ZipEntry> = {};
+  let zipEntries: Record<string, ZipEntry> = {};
   try {
     zipEntries = await zip.entries();
   } catch {


### PR DESCRIPTION
### Issue

Minor thing missed in https://github.com/awslabs/aws-sdk-js-find-v2/pull/15

### Description

Uses named imports StreamZipAsync and ZipEntry from node-stream-zip

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.