### PR TITLE
chore: move Lambda function processing part to worker_threads

### DIFF
--- a/src/scanLambdaFunction.worker.ts
+++ b/src/scanLambdaFunction.worker.ts
@@ -1,13 +1,13 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { getLambdaFunctionContents } from "./utils/getLambdaFunctionContents.ts";
 import { hasSdkV2InBundle } from "./utils/hasSdkV2InBundle.ts";
 import { JS_SDK_V2_MARKER } from "./constants.ts";
 
-const { zipPath } = workerData as { zipPath: string };
+const { packageJsonContents, bundleContent } = workerData as {
+  packageJsonContents: string[] | undefined;
+  bundleContent: string | undefined;
+};
 
-const scan = async () => {
-  const { packageJsonContents, bundleContent } = await getLambdaFunctionContents(zipPath);
-
+const scan = () => {
   if (packageJsonContents?.length) {
     for (const content of packageJsonContents) {
       try {
@@ -25,4 +25,4 @@ const scan = async () => {
   return JS_SDK_V2_MARKER.N;
 };
 
-scan().then((result) => parentPort?.postMessage(result));
+parentPort?.postMessage(scan());

--- a/src/scanLambdaFunctions.ts
+++ b/src/scanLambdaFunctions.ts
@@ -14,7 +14,7 @@ export const scanLambdaFunctions = async ({ region, yes }: LambdaCommandOptions 
   const functions = await getLambdaFunctions(client);
   const functionCount = functions.length;
 
-  const concurrency = Math.min(functionCount, cpus().length || 1);
+  const concurrency = Math.min(functionCount, cpus().length - 1 || 1);
   const codeSizeToDownload = functions.reduce((acc, fn) => acc + (fn.CodeSize || 0), 0);
   const codeSizeToSaveOnDisk = functions
     .map((fn) => fn.CodeSize || 0)


### PR DESCRIPTION
### Issue

The parallel processing added in https://github.com/awslabs/aws-sdk-js-find-v2/pull/18 is still done on a single thread.
The computation part of it, i.e. reading zip files can be done in different threads using worker_threads

### Description

Moves compute intensive part of reading Lambda function to Worker

### Testing

ToDo

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.