### PR TITLE
chore(ci): run bundle generation in parallel

### DIFF
--- a/scripts/generateBundles.ts
+++ b/scripts/generateBundles.ts
@@ -18,15 +18,23 @@ for (const fileName of jsFiles) {
   if (bundlerName === "esbuild") {
     // esbuild doesn't support config.
     promises.push(async () => {
-      console.log(`Running '${bundlerName}' with code '${fileName}'`);
-      await execAsync(`node ${filePath}`);
+      try {
+        console.log(`[${bundlerName}] Running with code '${fileName}'`);
+        await execAsync(`node ${filePath}`);
+      } catch (error) {
+        throw new Error(`[${bundlerName}] failed`, { cause: error });
+      }
     });
     continue;
   }
 
   promises.push(async () => {
-    console.log(`Running '${bundlerName}' with config '${fileName}'`);
-    await execAsync(`npx ${bundlerName} -c ${filePath}`);
+    try {
+      console.log(`[${bundlerName}] Running with config '${fileName}'`);
+      await execAsync(`npx ${bundlerName} -c ${filePath}`);
+    } catch (error) {
+      throw new Error(`[${bundlerName}] failed`, { cause: error });
+    }
   });
 }
 


### PR DESCRIPTION
### Issue

N/A

### Description

Runs bundle generation in parallel using p-limit

### Testing

The improvement is significant based on number of processors.

#### Before

Bundles generation took 25 seconds on 2021 Apple M1 Pro
```console
$ time yarn test:generate:bundles
...
yarn test:generate:bundles  34.34s user 5.17s system 156% cpu 25.222 total
```  

Bundles generation took 37s on GitHub Actions
https://github.com/awslabs/aws-sdk-js-find-v2/actions/runs/20452534642/job/58768365979?pr=39

#### After

Bundles generation takes 7 seconds on 2021 Apple M1 Pro
```console
$ time yarn test:generate:bundles
...
yarn test:generate:bundles  40.34s user 7.17s system 672% cpu 7.062 total
```

Bundles generation takes 22s on GitHub Actions
https://github.com/awslabs/aws-sdk-js-find-v2/actions/runs/20468290662/job/58817358129

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.