### PR TITLE
chore: enable relevant oxlint plugins

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,3 +1,3 @@
 {
-  "plugins": ["vitest"]
+  "plugins": ["import", "jsdoc", "promise", "vitest"]
 }


### PR DESCRIPTION
### Issue

https://oxc.rs/docs/guide/usage/linter/plugins

### Description

Enables the following oxlint plugins relevant to the project:
* import
* jsdoc
* promise

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.