### PR TITLE
chore(ci): group all deps into a single PR in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     schedule:
       interval: "monthly"
     versioning-strategy: "lockfile-only"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
### Issue

This will avoid dependabot PRs like these https://github.com/awslabs/aws-sdk-js-find-v2/pulls?q=sort%3Aupdated-desc+is%3Apr+is%3Aopen+author%3Aapp%2Fdependabot

Docs: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--

### Description

Groups all dependency updates into a single PR in dependabot

### Testing

N/A

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.