### PR TITLE
chore(ci): add explicit configuration for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: github/codeql-action/init@v4
         with:
-          languages: javascript-typescript, actions
+          languages: ${{ matrix.language }}
           config: |
             paths-ignore: [ "src/utils/__fixtures__/*.{cjs,mjs}" ]
       - uses: github/codeql-action/analyze@v4
-        with:
-          category: "/language:javascript-typescript,actions"


### PR DESCRIPTION
### Issue

CodeQL detects alarms in GitHub bundles which are used in tests and not in production code.
There are 45 reported in https://github.com/awslabs/aws-sdk-js-find-v2/security/code-scanning

These had to be manually visited in pull requests, and disabled one-by-one.
They usually reappear when bundle files are updated.

Docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan

### Description

Adds an explicit configuration for CodeQL retaining the recommendation from GitHub organization and disable scan for bundle files used in testing.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.