### PR TITLE
chore: move getLambdaFunctionScanOutput to utils folder

### DIFF
--- a/src/scanLambdaFunctions.spec.ts
+++ b/src/scanLambdaFunctions.spec.ts
@@ -4,13 +4,13 @@ import pLimit from "p-limit";
 
 import { getDownloadConfirmation } from "./utils/getDownloadConfirmation.ts";
 import { getLambdaFunctions } from "./utils/getLambdaFunctions.ts";
-import { getLambdaFunctionScanOutput } from "./getLambdaFunctionScanOutput.ts";
+import { getLambdaFunctionScanOutput } from "./utils/getLambdaFunctionScanOutput.ts";
 import { scanLambdaFunctions } from "./scanLambdaFunctions.ts";
 
 vi.mock("@aws-sdk/client-lambda");
-vi.mock("./getLambdaFunctionScanOutput.ts");
 vi.mock("./utils/getDownloadConfirmation.ts");
 vi.mock("./utils/getLambdaFunctions.ts");
+vi.mock("./utils/getLambdaFunctionScanOutput.ts");
 vi.mock("p-limit");
 
 describe("scanLambdaFunctions", () => {

--- a/src/scanLambdaFunctions.ts
+++ b/src/scanLambdaFunctions.ts
@@ -1,9 +1,9 @@
 import { Lambda } from "@aws-sdk/client-lambda";
 import pLimit from "p-limit";
 
-import { getLambdaFunctionScanOutput } from "./getLambdaFunctionScanOutput.ts";
 import { getDownloadConfirmation } from "./utils/getDownloadConfirmation.ts";
 import { getLambdaFunctions } from "./utils/getLambdaFunctions.ts";
+import { getLambdaFunctionScanOutput } from "./utils/getLambdaFunctionScanOutput.ts";
 
 export interface ScanLambdaFunctionsOptions {
   // AWS region to scan

--- a/src/utils/getLambdaFunctionScanOutput.spec.ts
+++ b/src/utils/getLambdaFunctionScanOutput.spec.ts
@@ -3,14 +3,14 @@ import { rm } from "node:fs/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getLambdaFunctionScanOutput } from "./getLambdaFunctionScanOutput.ts";
-import { downloadFile } from "./utils/downloadFile.ts";
-import { getLambdaFunctionContents } from "./utils/getLambdaFunctionContents.ts";
-import { hasSdkV2InBundle } from "./utils/hasSdkV2InBundle.ts";
+import { downloadFile } from "./downloadFile.ts";
+import { getLambdaFunctionContents } from "./getLambdaFunctionContents.ts";
+import { hasSdkV2InBundle } from "./hasSdkV2InBundle.ts";
 
 vi.mock("node:fs/promises");
-vi.mock("./utils/downloadFile.ts");
-vi.mock("./utils/getLambdaFunctionContents.ts");
-vi.mock("./utils/hasSdkV2InBundle.ts");
+vi.mock("./downloadFile.ts");
+vi.mock("./getLambdaFunctionContents.ts");
+vi.mock("./hasSdkV2InBundle.ts");
 
 describe("getLambdaFunctionScanOutput", () => {
   const mockClient = { getFunction: vi.fn() } as unknown as Lambda;

--- a/src/utils/getLambdaFunctionScanOutput.ts
+++ b/src/utils/getLambdaFunctionScanOutput.ts
@@ -1,10 +1,10 @@
 import type { Lambda } from "@aws-sdk/client-lambda";
-import { downloadFile } from "./utils/downloadFile.ts";
+import { downloadFile } from "./downloadFile.ts";
 import {
   getLambdaFunctionContents,
   type LambdaFunctionContents,
-} from "./utils/getLambdaFunctionContents.ts";
-import { hasSdkV2InBundle } from "./utils/hasSdkV2InBundle.ts";
+} from "./getLambdaFunctionContents.ts";
+import { hasSdkV2InBundle } from "./hasSdkV2InBundle.ts";
 
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";


### PR DESCRIPTION
### Issue

N/A

### Description

Moves getLambdaFunctionScanOutput to utils folder

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.