### PR TITLE
chore(ci): skip new bundle paths in CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,5 +20,5 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config: |
-            paths-ignore: [ "src/utils/__fixtures__/*.{cjs,mjs}" ]
+            paths-ignore: [ "src/utils/__fixtures__/{v2,v3}/build/*.{cjs,mjs}" ]
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Issue

Missed when bundle paths were updated in https://github.com/awslabs/aws-sdk-js-find-v2/pull/78

### Description

Skips new bundle paths in CodeQL

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.