### PR TITLE
chore(ci): remove check for diff in rolldown CJS artifacts

### DIFF
--- a/.github/workflows/test-generate-bundles.yml
+++ b/.github/workflows/test-generate-bundles.yml
@@ -29,6 +29,9 @@ jobs:
         run: sh scripts/generateBundles.sh --skip-build
       - name: check for changes
         run: |
+          # Stop checking for Rolldown CJS artifact since they're non-deterministic
+          # TODO: remove after it's fixed in https://github.com/rolldown/rolldown/issues/7646
+          git checkout -- src/utils/__fixtures__/v3/build/rolldown.cjs
           if [ -n "$(git status --porcelain)" ]; then
             echo "Error: Files were modified or added"
             git status


### PR DESCRIPTION
### Issue

* Bug report in https://github.com/rolldown/rolldown/issues/7646
* I noticed consistent failures six times when attempting to generate bundles without minification https://github.com/awslabs/aws-sdk-js-find-v2/actions/runs/20628103137/job/59242249933?pr=80

### Description

Remove check for diff in rolldown CJS artifacts

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.