### PR TITLE
chore(deps-dev): set 'aws-sdk' to exact 2.1693.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@tsconfig/node-ts": "^23.6.2",
     "@tsconfig/node20": "^20.1.8",
     "@types/node": "^20.14.8",
-    "aws-sdk": "^2.1692.0",
+    "aws-sdk": "2.1693.0",
     "esbuild": "~0.27.1",
     "oxfmt": "^0.21.0",
     "oxlint": "^1.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,7 +378,7 @@ __metadata:
     "@tsconfig/node-ts": "npm:^23.6.2"
     "@tsconfig/node20": "npm:^20.1.8"
     "@types/node": "npm:^20.14.8"
-    aws-sdk: "npm:^2.1692.0"
+    aws-sdk: "npm:2.1693.0"
     cli-table3: "npm:^0.6.5"
     commander: "npm:^14.0.2"
     compare-versions: "npm:^6.1.1"
@@ -4759,7 +4759,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-sdk@npm:^2.1692.0":
+"aws-sdk@npm:2.1693.0":
   version: 2.1693.0
   resolution: "aws-sdk@npm:2.1693.0"
   dependencies:


### PR DESCRIPTION
### Issue

Exact version is required for testing version in https://github.com/awslabs/aws-sdk-js-find-v2/pull/84

### Description

Sets 'aws-sdk' to exact 2.1693.0

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.