### PR TITLE
Use Maps for internal hashes instead of Objects

### DIFF
--- a/src/utils/getLambdaFunctionContents.spec.ts
+++ b/src/utils/getLambdaFunctionContents.spec.ts
@@ -30,7 +30,7 @@ describe("getLambdaFunctionContents", () => {
     mockZip.entries.mockRejectedValue(new Error("zip entries error"));
     const result = await getLambdaFunctionContents(mockZipPath);
 
-    expect(result).toEqual({ codeMap: {} });
+    expect(result).toEqual({ codeMap: new Map() });
     expect(mockZip.entryData).not.toHaveBeenCalled();
     expect(mockZip.close).toHaveBeenCalled();
   });
@@ -44,7 +44,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: {} });
+      expect(result).toEqual({ codeMap: new Map() });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("package.json");
       expect(mockZip.close).toHaveBeenCalled();
@@ -58,7 +58,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: {} });
+      expect(result).toEqual({ codeMap: new Map() });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("index.js");
       expect(mockZip.close).toHaveBeenCalled();
@@ -73,7 +73,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: {} });
+      expect(result).toEqual({ codeMap: new Map() });
       expect(mockZip.entryData).toHaveBeenCalledTimes(2);
       expect(mockZip.entryData).toHaveBeenNthCalledWith(1, "package.json");
       expect(mockZip.entryData).toHaveBeenNthCalledWith(2, "index.js");
@@ -93,8 +93,8 @@ describe("getLambdaFunctionContents", () => {
       const result = await getLambdaFunctionContents(mockZipPath);
 
       expect(result).toEqual({
-        codeMap: { "index.js": mockCode },
-        packageJsonMap: { "package.json": mockPackageJson },
+        codeMap: new Map([["index.js", mockCode]]),
+        packageJsonMap: new Map([["package.json", mockPackageJson]]),
       });
       expect(mockZip.entryData).toHaveBeenCalledTimes(2);
       expect(mockZip.entryData).toHaveBeenNthCalledWith(1, "package.json");
@@ -112,8 +112,8 @@ describe("getLambdaFunctionContents", () => {
       const result = await getLambdaFunctionContents(mockZipPath);
 
       expect(result).toEqual({
-        codeMap: {},
-        packageJsonMap: { "package.json": mockPackageJson },
+        codeMap: new Map(),
+        packageJsonMap: new Map([["package.json", mockPackageJson]]),
       });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("package.json");
@@ -127,7 +127,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: {} });
+      expect(result).toEqual({ codeMap: new Map() });
       expect(mockZip.entryData).not.toHaveBeenCalled();
       expect(mockZip.close).toHaveBeenCalled();
     });
@@ -147,11 +147,11 @@ describe("getLambdaFunctionContents", () => {
       const result = await getLambdaFunctionContents(mockZipPath);
 
       expect(result).toEqual({
-        codeMap: {},
-        packageJsonMap: {
-          "package.json": mockPackageJsons.root,
-          "packages/app/package.json": mockPackageJsons.app,
-        },
+        codeMap: new Map(),
+        packageJsonMap: new Map([
+          ["package.json", mockPackageJsons.root],
+          ["packages/app/package.json", mockPackageJsons.app],
+        ]),
       });
       expect(mockZip.entryData).toHaveBeenCalledTimes(2);
       expect(mockZip.entryData).toHaveBeenNthCalledWith(1, "package.json");
@@ -174,9 +174,9 @@ describe("getLambdaFunctionContents", () => {
       const result = await getLambdaFunctionContents(mockZipPath);
 
       expect(result).toEqual({
-        codeMap: {},
-        packageJsonMap: { "package.json": mockPackageJson },
-        awsSdkPackageJsonMap: { "node_modules/aws-sdk/package.json": awsSdkPackageJson },
+        codeMap: new Map(),
+        packageJsonMap: new Map([["package.json", mockPackageJson]]),
+        awsSdkPackageJsonMap: new Map([["node_modules/aws-sdk/package.json", awsSdkPackageJson]]),
       });
     });
 
@@ -195,11 +195,11 @@ describe("getLambdaFunctionContents", () => {
       const result = await getLambdaFunctionContents(mockZipPath);
 
       expect(result).toEqual({
-        codeMap: {},
-        packageJsonMap: { "package.json": mockPackageJson },
-        awsSdkPackageJsonMap: {
-          "packages/app/node_modules/aws-sdk/package.json": awsSdkPackageJson,
-        },
+        codeMap: new Map(),
+        packageJsonMap: new Map([["package.json", mockPackageJson]]),
+        awsSdkPackageJsonMap: new Map([
+          ["packages/app/node_modules/aws-sdk/package.json", awsSdkPackageJson],
+        ]),
       });
     });
   });
@@ -213,7 +213,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: { "index.js": mockCode } });
+      expect(result).toEqual({ codeMap: new Map([["index.js", mockCode]]) });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("index.js");
       expect(mockZip.close).toHaveBeenCalled();
@@ -227,7 +227,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: { "index.mjs": mockCode } });
+      expect(result).toEqual({ codeMap: new Map([["index.mjs", mockCode]]) });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("index.mjs");
       expect(mockZip.close).toHaveBeenCalled();
@@ -241,7 +241,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: { "index.cjs": mockCode } });
+      expect(result).toEqual({ codeMap: new Map([["index.cjs", mockCode]]) });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("index.cjs");
       expect(mockZip.close).toHaveBeenCalled();
@@ -255,7 +255,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: { "index.ts": mockCode } });
+      expect(result).toEqual({ codeMap: new Map([["index.ts", mockCode]]) });
       expect(mockZip.entryData).toHaveBeenCalledOnce();
       expect(mockZip.entryData).toHaveBeenCalledWith("index.ts");
       expect(mockZip.close).toHaveBeenCalled();
@@ -271,7 +271,10 @@ describe("getLambdaFunctionContents", () => {
       const result = await getLambdaFunctionContents(mockZipPath);
 
       expect(result).toEqual({
-        codeMap: { "index.js": mockCode, "utils.js": mockCode },
+        codeMap: new Map([
+          ["index.js", mockCode],
+          ["utils.js", mockCode],
+        ]),
       });
       expect(mockZip.entryData).toHaveBeenCalledTimes(2);
       expect(mockZip.entryData).toHaveBeenNthCalledWith(1, "index.js");
@@ -286,7 +289,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: {} });
+      expect(result).toEqual({ codeMap: new Map() });
       expect(mockZip.entryData).not.toHaveBeenCalled();
       expect(mockZip.close).toHaveBeenCalled();
     });
@@ -298,7 +301,7 @@ describe("getLambdaFunctionContents", () => {
 
       const result = await getLambdaFunctionContents(mockZipPath);
 
-      expect(result).toEqual({ codeMap: {} });
+      expect(result).toEqual({ codeMap: new Map() });
       expect(mockZip.entryData).not.toHaveBeenCalled();
       expect(mockZip.close).toHaveBeenCalled();
     });

--- a/src/utils/getLambdaFunctionScanOutput.spec.ts
+++ b/src/utils/getLambdaFunctionScanOutput.spec.ts
@@ -56,7 +56,7 @@ describe("getLambdaFunctionScanOutput", () => {
       Configuration: { Handler: "index.handler" },
     });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": "bundle content" },
+      codeMap: new Map([["index.js", "bundle content"]]),
     });
     vi.mocked(hasSdkV2InBundle).mockReturnValue(true);
 
@@ -85,8 +85,8 @@ describe("getLambdaFunctionScanOutput", () => {
       Configuration: { Handler: "index.handler" },
     });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.mjs": 'import AWS from "aws-sdk";' },
-      packageJsonMap: { "package.json": '{"dependencies":{"aws-sdk":"^2.0.0"}}' },
+      codeMap: new Map([["index.mjs", 'import AWS from "aws-sdk";']]),
+      packageJsonMap: new Map([["package.json", '{"dependencies":{"aws-sdk":"^2.0.0"}}']]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -117,8 +117,8 @@ describe("getLambdaFunctionScanOutput", () => {
       Configuration: { Handler: "index.handler" },
     });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": "no sdk here" },
-      packageJsonMap: { "package.json": '{"dependencies":{}}' },
+      codeMap: new Map([["index.js", "no sdk here"]]),
+      packageJsonMap: new Map([["package.json", '{"dependencies":{}}']]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(false);
 
@@ -142,7 +142,7 @@ describe("getLambdaFunctionScanOutput", () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({
       Code: { Location: codeLocation },
     });
-    vi.mocked(getLambdaFunctionContents).mockResolvedValue({ codeMap: {} });
+    vi.mocked(getLambdaFunctionContents).mockResolvedValue({ codeMap: new Map() });
 
     const result = await getLambdaFunctionScanOutput(mockClient, {
       functionName,
@@ -167,8 +167,8 @@ describe("getLambdaFunctionScanOutput", () => {
       Code: { Location: codeLocation },
     });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "package.json": "invalid json" },
+      codeMap: new Map([["index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["package.json", "invalid json"]]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -239,8 +239,8 @@ describe("getLambdaFunctionScanOutput", () => {
     const sdkVersion = "2.1693.0";
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "package.json": `{"dependencies":{"aws-sdk":"${sdkVersion}"}}` },
+      codeMap: new Map([["index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["package.json", `{"dependencies":{"aws-sdk":"${sdkVersion}"}}`]]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -263,8 +263,8 @@ describe("getLambdaFunctionScanOutput", () => {
   it("returns error when version satisfies check throws", async () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "package.json": '{"dependencies":{"aws-sdk":"invalid"}}' },
+      codeMap: new Map([["index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["package.json", '{"dependencies":{"aws-sdk":"invalid"}}']]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -284,9 +284,11 @@ describe("getLambdaFunctionScanOutput", () => {
   it("uses version from node_modules/aws-sdk/package.json when dependency is a range", async () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "package.json": '{"dependencies":{"aws-sdk":"^2.0.0"}}' },
-      awsSdkPackageJsonMap: { "node_modules/aws-sdk/package.json": '{"version":"2.1692.0"}' },
+      codeMap: new Map([["index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["package.json", '{"dependencies":{"aws-sdk":"^2.0.0"}}']]),
+      awsSdkPackageJsonMap: new Map([
+        ["node_modules/aws-sdk/package.json", '{"version":"2.1692.0"}'],
+      ]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -303,11 +305,11 @@ describe("getLambdaFunctionScanOutput", () => {
   it("uses version from nested node_modules/aws-sdk/package.json", async () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "subdir/index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "subdir/package.json": '{"dependencies":{"aws-sdk":"^2.0.0"}}' },
-      awsSdkPackageJsonMap: {
-        "subdir/node_modules/aws-sdk/package.json": '{"version":"2.1000.0"}',
-      },
+      codeMap: new Map([["subdir/index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["subdir/package.json", '{"dependencies":{"aws-sdk":"^2.0.0"}}']]),
+      awsSdkPackageJsonMap: new Map([
+        ["subdir/node_modules/aws-sdk/package.json", '{"version":"2.1000.0"}'],
+      ]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -324,9 +326,11 @@ describe("getLambdaFunctionScanOutput", () => {
   it("falls back to root node_modules when nested not found", async () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "subdir/index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "subdir/package.json": '{"dependencies":{"aws-sdk":"^2.0.0"}}' },
-      awsSdkPackageJsonMap: { "node_modules/aws-sdk/package.json": '{"version":"2.500.0"}' },
+      codeMap: new Map([["subdir/index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["subdir/package.json", '{"dependencies":{"aws-sdk":"^2.0.0"}}']]),
+      awsSdkPackageJsonMap: new Map([
+        ["node_modules/aws-sdk/package.json", '{"version":"2.500.0"}'],
+      ]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -343,9 +347,9 @@ describe("getLambdaFunctionScanOutput", () => {
   it("ignores invalid aws-sdk package.json in node_modules", async () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "package.json": '{"dependencies":{"aws-sdk":"^2.0.0"}}' },
-      awsSdkPackageJsonMap: { "node_modules/aws-sdk/package.json": "invalid json" },
+      codeMap: new Map([["index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["package.json", '{"dependencies":{"aws-sdk":"^2.0.0"}}']]),
+      awsSdkPackageJsonMap: new Map([["node_modules/aws-sdk/package.json", "invalid json"]]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -362,8 +366,8 @@ describe("getLambdaFunctionScanOutput", () => {
   it("returns false when sdk found in code but not in package.json dependencies", async () => {
     vi.mocked(mockClient.getFunction).mockResolvedValue({ Code: { Location: codeLocation } });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "index.js": 'require("aws-sdk")' },
-      packageJsonMap: { "package.json": '{"dependencies":{}}' },
+      codeMap: new Map([["index.js", 'require("aws-sdk")']]),
+      packageJsonMap: new Map([["package.json", '{"dependencies":{}}']]),
     });
     vi.mocked(hasSdkV2InFile).mockReturnValue(true);
 
@@ -383,7 +387,7 @@ describe("getLambdaFunctionScanOutput", () => {
       Configuration: { Handler: "handler.main" },
     });
     vi.mocked(getLambdaFunctionContents).mockResolvedValue({
-      codeMap: { "handler.mjs": "bundle content" },
+      codeMap: new Map([["handler.mjs", "bundle content"]]),
     });
     vi.mocked(hasSdkV2InBundle).mockReturnValue(true);
 


### PR DESCRIPTION
### Issue

Missed in https://github.com/awslabs/aws-sdk-js-find-v2/pull/93

### Description

Use Maps for internal hashes instead of Objects. They already have Map suffix.

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.