### PR TITLE
chore: move AWS_SDK_PACKAGE_JSON to constants

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,5 +1,9 @@
-export const PACKAGE_JSON = "package.json";
+import { join } from "node:path";
 
 export const NODE_MODULES = "node_modules";
 
 export const AWS_SDK = "aws-sdk";
+
+export const PACKAGE_JSON = "package.json";
+
+export const AWS_SDK_PACKAGE_JSON = join(NODE_MODULES, AWS_SDK, PACKAGE_JSON);

--- a/src/utils/getCodePathToSdkVersionMap.ts
+++ b/src/utils/getCodePathToSdkVersionMap.ts
@@ -1,8 +1,6 @@
 import { dirname, join } from "node:path";
 
-import { AWS_SDK, NODE_MODULES, PACKAGE_JSON } from "./constants.ts";
-
-const AWS_SDK_PACKAGE_JSON = join(NODE_MODULES, AWS_SDK, PACKAGE_JSON);
+import { AWS_SDK, AWS_SDK_PACKAGE_JSON, PACKAGE_JSON } from "./constants.ts";
 
 const safeParse = (json: string) => {
   try {

--- a/src/utils/getLambdaFunctionContents.ts
+++ b/src/utils/getLambdaFunctionContents.ts
@@ -1,6 +1,5 @@
 import StreamZip from "node-stream-zip";
-import { AWS_SDK, NODE_MODULES, PACKAGE_JSON } from "./constants.ts";
-import { join } from "node:path";
+import { AWS_SDK_PACKAGE_JSON, NODE_MODULES, PACKAGE_JSON } from "./constants.ts";
 
 export interface LambdaFunctionContents {
   /**
@@ -50,7 +49,7 @@ export const getLambdaFunctionContents = async (
   for (const zipEntry of Object.values(zipEntries)) {
     // Skip 'node_modules' directory, except for aws-sdk package.json file.
     if (zipEntry.name.includes(`${NODE_MODULES}/`)) {
-      if (zipEntry.name.endsWith(join(NODE_MODULES, AWS_SDK, PACKAGE_JSON)) && zipEntry.isFile) {
+      if (zipEntry.name.endsWith(AWS_SDK_PACKAGE_JSON) && zipEntry.isFile) {
         const packageJsonContent = await zip.entryData(zipEntry.name);
         awsSdkPackageJsonMap.set(zipEntry.name, packageJsonContent.toString());
       }


### PR DESCRIPTION
### Issue

Noticed while implementing https://github.com/awslabs/aws-sdk-js-find-v2/issues/91

### Description

Move AWS_SDK_PACKAGE_JSON to constants.ts

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.