### PR TITLE
chore: pass Lambda FunctionConfiguration to getLambdaFunctionScanOutput

### DIFF
--- a/src/scanLambdaFunctions.ts
+++ b/src/scanLambdaFunctions.ts
@@ -75,16 +75,12 @@ export const scanLambdaFunctions = async (options: ScanLambdaFunctionsOptions) =
     }
   }
 
-  const clientRegion = await client.config.region();
-
   const limit = pLimit(concurrency);
   const scanOutput = await Promise.all(
     functions.map((fn) =>
       limit(() =>
         getLambdaFunctionScanOutput(client, {
-          functionName: fn.FunctionName!,
-          region: clientRegion,
-          runtime: fn.Runtime!,
+          functionConfiguration: fn,
           sdkVersionRange: sdk,
         }),
       ),


### PR DESCRIPTION
### Issue

Required in https://github.com/awslabs/aws-sdk-js-find-v2/pull/99 to process Lambda Layers

### Description

Passes Lambda FunctionConfiguration to getLambdaFunctionScanOutput

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.