### PR TITLE
chore(ci): explicitly set languages for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,5 +25,5 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config: |
-            paths-ignore: [ 'src/utils/__fixtures__/{v2,v3}/build/*.{cjs,mjs}' ]
+            paths-ignore: [ "src/utils/__fixtures__/{v2,v3}/build/*.{cjs,mjs}" ]
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Issue

The docs was misintepreted https://github.com/github/codeql-action/blob/5d4e8d1aca955e8d8589aabd499c5cae939e33c7/init/action.yml#L22 when the custom action was originally written.

> Due to the performance benefit of parallelizing builds, we recommend specifying languages to
      analyze using a matrix and providing `\$\{{ matrix.language }}` as this input.

The existing check for `matrix.language` is ignored, and CodeQL auto detects javascript and action

### Description

Explicitly sets languages for codeql

Docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#changing-the-languages-that-are-analyzed

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.