### PR TITLE
chore(ci): use '**' in codeql paths-ignore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,5 +25,8 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           config: |
-            paths-ignore: [ "src/utils/__fixtures__/{v2,v3}/build/*.{cjs,mjs}" ]
+            paths-ignore:
+              - 'src/utils/__fixtures__/v2/build/**'
+              - 'src/utils/__fixtures__/v3/build/**'
+              - 'src/utils/__fixtures__/files/**'
       - uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
### Issue

Docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning#specifying-directories-to-scan

### Description

Uses '**' in codeql paths-ignore and removes `{` and `}`

### Testing

CI

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.