### PR TITLE
chore(ci): remove redundant setting of node-version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,6 @@ jobs:
         run: npm i -g corepack
       - uses: actions/setup-node@v6
         with:
-          node-version: "24.x" # Trusted publishing requires npm >=v11.5.1
           cache: "yarn"
 
       - run: yarn


### PR DESCRIPTION
### Issue

Node.js version is v24 by default in `actions/setup-node@v5` onwards
Docs: https://github.com/actions/setup-node#breaking-changes-in-v5

### Description

Removes redundant setting of node-version from push.yml

### Testing

To be done post merge since release action is not run on PR.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.